### PR TITLE
Remove explicit dependence on redis

### DIFF
--- a/katsdpservices/argparse.py
+++ b/katsdpservices/argparse.py
@@ -7,7 +7,6 @@ from __future__ import print_function, division, absolute_import
 import argparse
 try:
     import katsdptelstate
-    import redis
 except ImportError:
     pass
 
@@ -138,7 +137,7 @@ class ArgumentParser(argparse.ArgumentParser):
             if config_args.telstate is not None:
                 try:
                     namespace.telstate = katsdptelstate.TelescopeState(config_args.telstate)
-                except redis.ConnectionError as e:
+                except katsdptelstate.ConnectionError as e:
                     self.error(str(e))
                 namespace.name = config_args.name
                 self._load_defaults(namespace.telstate, namespace.name)


### PR DESCRIPTION
Since katsdptelstate PR [#61](https://github.com/ska-sa/katsdptelstate/pull/61), redis ConnectionErrors are repackaged as katsdptelstate exceptions, which means that the end user no longer needs to know about redis.