### PR TITLE
Make add_aiomonitor_arguments a free function

### DIFF
--- a/katsdpservices/__init__.py
+++ b/katsdpservices/__init__.py
@@ -12,8 +12,8 @@ else:
 # END VERSION CHECK
 
 
-from .logging import setup_logging                     # noqa: F401
-from .restart import setup_restart, restart_process    # noqa: F401
-from .argparse import ArgumentParser                   # noqa: F401
-from .interfaces import get_interface_address          # noqa: F401
-from .aiomonitor import start_aiomonitor               # noqa: F401
+from .logging import setup_logging                                   # noqa: F401
+from .restart import setup_restart, restart_process                  # noqa: F401
+from .argparse import ArgumentParser                                 # noqa: F401
+from .interfaces import get_interface_address                        # noqa: F401
+from .aiomonitor import start_aiomonitor, add_aiomonitor_arguments   # noqa: F401

--- a/katsdpservices/aiomonitor.py
+++ b/katsdpservices/aiomonitor.py
@@ -44,3 +44,28 @@ def start_aiomonitor(loop, args, locals):
             port=args.aiomonitor_port,
             console_port=args.aioconsole_port,
             locals=locals)
+
+
+def add_aiomonitor_arguments(parser):
+    """Add a set of arguments for controlling aiomonitor.
+
+    See :func:`.start_aiomonitor` for details.
+
+    Parameters
+    ----------
+    parser : :class:`argparse.ArgumentParser`
+        Parser to which arguments will be added.
+    """
+    import aiomonitor
+    parser.add_argument(
+        '--aiomonitor', action='store_true', default=False,
+        help='run aiomonitor debugging server')
+    parser.add_argument(
+        '--aiomonitor-host', type=str, default=aiomonitor.MONITOR_HOST,
+        help='bind host for aiomonitor/aioconsole [%(default)s]')
+    parser.add_argument(
+        '--aiomonitor-port', type=int, default=aiomonitor.MONITOR_PORT,
+        help='port for aiomonitor [%(default)s]')
+    parser.add_argument(
+        '--aioconsole-port', type=int, default=aiomonitor.CONSOLE_PORT,
+        help='port for aioconsole [%(default)s]')

--- a/katsdpservices/argparse.py
+++ b/katsdpservices/argparse.py
@@ -141,18 +141,9 @@ class ArgumentParser(argparse.ArgumentParser):
     def add_aiomonitor_arguments(self):
         """Add a set of arguments for controlling aiomonitor.
 
-        See :func:`.start_aiomonitor` for details.
+        .. deprecated:: June 2019
+
+            Use the :func:`~.add_aiomonitor_arguments` free function instead.
         """
-        import aiomonitor
-        self.add_argument(
-            '--aiomonitor', action='store_true', default=False,
-            help='run aiomonitor debugging server')
-        self.add_argument(
-            '--aiomonitor-host', type=str, default=aiomonitor.MONITOR_HOST,
-            help='bind host for aiomonitor/aioconsole [%(default)s]')
-        self.add_argument(
-            '--aiomonitor-port', type=int, default=aiomonitor.MONITOR_PORT,
-            help='port for aiomonitor [%(default)s]')
-        self.add_argument(
-            '--aioconsole-port', type=int, default=aiomonitor.CONSOLE_PORT,
-            help='port for aioconsole [%(default)s]')
+        from .aiomonitor import add_aiomonitor_arguments
+        add_aiomonitor_arguments(self)

--- a/katsdpservices/test/test_aiomonitor.py
+++ b/katsdpservices/test/test_aiomonitor.py
@@ -9,7 +9,7 @@ import unittest
 import mock
 import six
 
-from .. import ArgumentParser, start_aiomonitor
+from .. import ArgumentParser, start_aiomonitor, add_aiomonitor_arguments
 
 
 @unittest.skipIf(six.PY2, 'Only supported on Python 3')
@@ -18,7 +18,7 @@ class TestStartAiomonitor(unittest.TestCase):
         import asyncio
 
         self.parser = ArgumentParser()
-        self.parser.add_aiomonitor_arguments()
+        add_aiomonitor_arguments(self.parser)
         patcher = mock.patch('aiomonitor.start_monitor')
         self.mock_start = patcher.start()
         self.addCleanup(patcher.stop)


### PR DESCRIPTION
It was part of the custom ArgumentParser, but there are times one wants
to use aiomonitor but not get arguments from telstate (e.g. master
controller).