### PR TITLE
Drop Python 2 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 
 @Library('katsdpjenkins') _
 katsdp.killOldJobs()
-katsdp.standardBuild(python2: true, python3: true)
+katsdp.standardBuild(python2: false, python3: true)
 katsdp.mail('sdpdev+katsdpservices@ska.ac.za')

--- a/katsdpservices/aiomonitor.py
+++ b/katsdpservices/aiomonitor.py
@@ -1,7 +1,6 @@
 """Utilities to simplify starting aiomonitor"""
 
 
-
 class _DummyContext:
     """Context manager that does nothing"""
     def __enter__(self):

--- a/katsdpservices/aiomonitor.py
+++ b/katsdpservices/aiomonitor.py
@@ -1,9 +1,8 @@
 """Utilities to simplify starting aiomonitor"""
 
-from __future__ import print_function, division, absolute_import
 
 
-class _DummyContext(object):
+class _DummyContext:
     """Context manager that does nothing"""
     def __enter__(self):
         return self

--- a/katsdpservices/argparse.py
+++ b/katsdpservices/argparse.py
@@ -3,7 +3,6 @@
 See :class:`ArgumentParser` for details.
 """
 
-from __future__ import print_function, division, absolute_import
 import argparse
 try:
     import katsdptelstate
@@ -20,7 +19,7 @@ class _HelpAction(argparse.Action):
                  dest=argparse.SUPPRESS,
                  default=argparse.SUPPRESS,
                  help=None):
-        super(_HelpAction, self).__init__(
+        super().__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
@@ -74,12 +73,12 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, *args, **kwargs):
         self.config_key = kwargs.pop('config_key', 'config')
-        super(ArgumentParser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Create a separate parser that will extract only the special args
         self.config_parser = argparse.ArgumentParser(add_help=False)
         self.config_parser.add_argument('-h', '--help', action=_HelpAction,
                                         default=argparse.SUPPRESS, parser=self)
-        for parser in [super(ArgumentParser, self), self.config_parser]:
+        for parser in [super(), self.config_parser]:
             parser.add_argument(
                 '--telstate', help='Telescope state repository from which to retrieve config',
                 metavar='HOST[:PORT]')
@@ -94,7 +93,7 @@ class ArgumentParser(argparse.ArgumentParser):
         # :meth:`add_argument_group` and :meth:`add_mutually_exclusive_group`,
         # parent parsers etc.
         bad_names = [None, argparse.SUPPRESS, 'help'] + self._SPECIAL_NAMES
-        return set(action.dest for action in self._actions if action.dest not in bad_names)
+        return {action.dest for action in self._actions if action.dest not in bad_names}
 
     def _load_defaults(self, telstate, name):
         config_dict = telstate.get(self.config_key, {})
@@ -113,13 +112,13 @@ class ArgumentParser(argparse.ArgumentParser):
 
         valid_keys = self._valid_keys()
         defaults = {key: value for key, value in config.items() if key in valid_keys}
-        super(ArgumentParser, self).set_defaults(**defaults)
+        super().set_defaults(**defaults)
 
     def set_defaults(self, **kwargs):
         for special in self._SPECIAL_NAMES:
             if special in kwargs:
                 self.config_parser.set_defaults(**{special: kwargs.pop(special)})
-        super(ArgumentParser, self).set_defaults(**kwargs)
+        super().set_defaults(**kwargs)
 
     def parse_known_args(self, args=None, namespace=None):
         if namespace is None:
@@ -136,7 +135,7 @@ class ArgumentParser(argparse.ArgumentParser):
                     self.error(str(e))
                 namespace.name = config_args.name
                 self._load_defaults(namespace.telstate, namespace.name)
-        return super(ArgumentParser, self).parse_known_args(other, namespace)
+        return super().parse_known_args(other, namespace)
 
     def add_aiomonitor_arguments(self):
         """Add a set of arguments for controlling aiomonitor.

--- a/katsdpservices/logging.py
+++ b/katsdpservices/logging.py
@@ -19,7 +19,6 @@ received, and exception hooks are installed so that unhandled exceptions are
 logged rather than merely printing to stderr.
 """
 
-from __future__ import print_function, division, absolute_import
 import logging
 import os
 import sys
@@ -42,7 +41,7 @@ class OnelineFormatter(logging.Formatter):
     are replaced by "\\".
     """
     def format(self, record):
-        s = super(OnelineFormatter, self).format(record)
+        s = super().format(record)
         return s.replace('\\', r'\\').replace('\n', r'\ ')
 
 
@@ -95,7 +94,7 @@ def docker_container_id():
                 match = regex.search(line)
                 if match:
                     return match.group(1)
-    except (OSError, IOError):
+    except OSError:
         pass
     return None
 

--- a/katsdpservices/restart.py
+++ b/katsdpservices/restart.py
@@ -1,5 +1,4 @@
 """Utility to make the process restart itself on SIGHUP"""
-from __future__ import print_function, division, absolute_import
 import sys
 import os.path
 import fcntl
@@ -30,12 +29,12 @@ def restart_process():
                     try:
                         flags = fcntl.fcntl(fd, fcntl.F_GETFD)
                         fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
-                    except (OSError, IOError):
+                    except OSError:
                         # This is guaranteed to happen, because the fd used by
                         # os.listdir will be in the list, but is closed by the
                         # time we try to change the flags on it.
                         pass
-    except (OSError, IOError):
+    except OSError:
         logging.warn('Could not read /proc/self/fd')
     # Ensure any logging gets properly flushed
     sys.stdout.flush()

--- a/katsdpservices/test/test_aiomonitor.py
+++ b/katsdpservices/test/test_aiomonitor.py
@@ -7,12 +7,10 @@ imports are delayed.
 import unittest
 
 import mock
-import six
 
 from .. import ArgumentParser, start_aiomonitor, add_aiomonitor_arguments
 
 
-@unittest.skipIf(six.PY2, 'Only supported on Python 3')
 class TestStartAiomonitor(unittest.TestCase):
     def setUp(self):
         import asyncio

--- a/katsdpservices/test/test_aiomonitor.py
+++ b/katsdpservices/test/test_aiomonitor.py
@@ -5,8 +5,7 @@ imports are delayed.
 """
 
 import unittest
-
-import mock
+from unittest import mock
 
 from .. import ArgumentParser, start_aiomonitor, add_aiomonitor_arguments
 

--- a/katsdpservices/test/test_argparse.py
+++ b/katsdpservices/test/test_argparse.py
@@ -1,7 +1,5 @@
 """Tests for :mod:`katsdpservices.argparse`."""
 
-from __future__ import print_function, division, absolute_import
-
 import unittest
 from unittest import mock
 

--- a/katsdpservices/test/test_argparse.py
+++ b/katsdpservices/test/test_argparse.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division, absolute_import
 import mock
-import unittest2 as unittest
+import unittest
 from katsdpservices import ArgumentParser
 
 

--- a/katsdpservices/test/test_argparse.py
+++ b/katsdpservices/test/test_argparse.py
@@ -1,8 +1,10 @@
 """Tests for :mod:`katsdpservices.argparse`."""
 
 from __future__ import print_function, division, absolute_import
-import mock
+
 import unittest
+from unittest import mock
+
 from katsdpservices import ArgumentParser
 
 

--- a/katsdpservices/test/test_interfaces.py
+++ b/katsdpservices/test/test_interfaces.py
@@ -1,8 +1,10 @@
 """Tests for :mod:`katsdpservices.interfaces`."""
 
-import mock
 import unittest
+from unittest import mock
+
 import netifaces
+
 from katsdpservices import get_interface_address
 
 

--- a/katsdpservices/test/test_logging.py
+++ b/katsdpservices/test/test_logging.py
@@ -134,9 +134,7 @@ class TestLogging(unittest.TestCase):
         if extra:
             expected["_hello"] = "world"
             expected["_number"] = 3
-        # It's only set on Python 3
-        if "_stack_info" in data:
-            expected["_stack_info"] = None
+        expected["_stack_info"] = None
         self.assertEqual(data, expected)
 
     def test_gelf_basic(self):

--- a/katsdpservices/test/test_logging.py
+++ b/katsdpservices/test/test_logging.py
@@ -11,9 +11,8 @@ import signal
 import json
 import zlib
 from contextlib import closing
-
 import unittest
-import mock
+from unittest import mock
 
 import katsdpservices
 

--- a/katsdpservices/test/test_logging.py
+++ b/katsdpservices/test/test_logging.py
@@ -6,6 +6,7 @@ import logging
 import socket
 import os
 import re
+import io
 import signal
 import json
 import zlib
@@ -13,7 +14,6 @@ from contextlib import closing
 
 import unittest2 as unittest
 import mock
-import six
 
 import katsdpservices
 
@@ -40,7 +40,7 @@ class TestLogging(unittest.TestCase):
 
     def setUp(self):
         # Grab the stderr written by the logger
-        self.stderr = self._create_patch('sys.stderr', new_callable=six.StringIO)
+        self.stderr = self._create_patch('sys.stderr', new_callable=io.StringIO)
         # Point root away from the actual root logger, so that we don't break
         # that.
         self.logger = self._create_patch(

--- a/katsdpservices/test/test_logging.py
+++ b/katsdpservices/test/test_logging.py
@@ -1,6 +1,5 @@
 """Tests for :mod:`katsdpservices.logging`"""
 
-from __future__ import print_function, division, absolute_import
 import time
 import logging
 import socket
@@ -120,24 +119,24 @@ class TestLogging(unittest.TestCase):
         data = json.loads(raw.decode('utf-8'))
         # This dictionary may need to be updated depending on the implementation
         expected = {
-            u"timestamp": self.time.return_value,
-            u"version": u"1.1",
-            u"short_message": u"info message",
-            u"_logger_name": u"katsdpservices.test.dummy",
-            u"_file": mock.ANY,
-            u"_line": mock.ANY,
-            u"_func": u"_test_gelf",
-            u"_module": u"test_logging",
-            u"_docker.id": container_id,
-            u"level": 6,
-            u"host": u"myhost" if localname else mock.ANY
+            "timestamp": self.time.return_value,
+            "version": "1.1",
+            "short_message": "info message",
+            "_logger_name": "katsdpservices.test.dummy",
+            "_file": mock.ANY,
+            "_line": mock.ANY,
+            "_func": "_test_gelf",
+            "_module": "test_logging",
+            "_docker.id": container_id,
+            "level": 6,
+            "host": "myhost" if localname else mock.ANY
         }
         if extra:
-            expected[u"_hello"] = u"world"
-            expected[u"_number"] = 3
+            expected["_hello"] = "world"
+            expected["_number"] = 3
         # It's only set on Python 3
-        if u"_stack_info" in data:
-            expected[u"_stack_info"] = None
+        if "_stack_info" in data:
+            expected["_stack_info"] = None
         self.assertEqual(data, expected)
 
     def test_gelf_basic(self):

--- a/katsdpservices/test/test_logging.py
+++ b/katsdpservices/test/test_logging.py
@@ -12,7 +12,7 @@ import json
 import zlib
 from contextlib import closing
 
-import unittest2 as unittest
+import unittest
 import mock
 
 import katsdpservices

--- a/katsdpservices/test/test_restart.py
+++ b/katsdpservices/test/test_restart.py
@@ -5,7 +5,7 @@ import mock
 import os
 import signal
 import time
-import unittest2 as unittest
+import unittest
 import katsdpservices
 
 

--- a/katsdpservices/test/test_restart.py
+++ b/katsdpservices/test/test_restart.py
@@ -1,11 +1,12 @@
 """Tests for :mod:`katsdpservices.restart`"""
 
 from __future__ import print_function, division, absolute_import
-import mock
 import os
 import signal
 import time
 import unittest
+from unittest import mock
+
 import katsdpservices
 
 

--- a/katsdpservices/test/test_restart.py
+++ b/katsdpservices/test/test_restart.py
@@ -1,6 +1,5 @@
 """Tests for :mod:`katsdpservices.restart`"""
 
-from __future__ import print_function, division, absolute_import
 import os
 import signal
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,12 @@
-aiomonitor; python_version>='3'
-aioconsole; python_version>='3'
-backports-abc; python_version<'3'
-backports.ssl-match-hostname; python_version<'3'
+aiomonitor
+aioconsole
 certifi
 fakeredis
-futures; python_version<'3'
-ipaddress; python_version<'3'
 redis
 msgpack
 netifaces
 numpy
 pygelf
-singledispatch; python_version<'3'
 six
-terminaltables; python_version>='3'
+terminaltables
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ msgpack
 netifaces
 numpy
 pygelf
-six
 terminaltables
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-tests_require = ['mock', 'nose', 'unittest2', 'six', 'katsdptelstate',
+tests_require = ['mock', 'nose', 'unittest2', 'katsdptelstate',
                  'aiomonitor; python_version>="3"']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-tests_require = ['mock', 'nose', 'unittest2', 'katsdptelstate',
-                 'aiomonitor; python_version>="3"']
+tests_require = ['mock', 'nose', 'katsdptelstate', 'aiomonitor']
 
 setup(
     name="katsdpservices",

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
         "argparse": ["katsdptelstate"],
         "aiomonitor": ["aiomonitor"],
         "test": tests_require},
+    python_requires='>=3.5',
     use_katversion=True
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-tests_require = ['mock', 'nose', 'katsdptelstate', 'aiomonitor']
+tests_require = ['nose', 'katsdptelstate', 'aiomonitor']
 
 setup(
     name="katsdpservices",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,5 @@
-argparse                  # via unittest2
 coverage
 funcsigs                  # via mock
-linecache2                # via traceback2
 mock
 nose
 pbr                       # via mock
-traceback2                # via unittest2
-unittest2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,2 @@
 coverage
-funcsigs                  # via mock
-mock
 nose
-pbr                       # via mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,5 @@ linecache2                # via traceback2
 mock
 nose
 pbr                       # via mock
-six
 traceback2                # via unittest2
 unittest2


### PR DESCRIPTION
katsdpdisp was the last Python 2 user, and it's been migrated to Python 3.

Most of the changes are made by pyupgrade, but they're in a separate commit so they can be reviewed independently of the others.