### PR TITLE
Add telstate_endpoint attribute to argparse result

### DIFF
--- a/katsdpservices/argparse.py
+++ b/katsdpservices/argparse.py
@@ -21,7 +21,7 @@ See :class:`ArgumentParser` for details.
 
 import argparse
 try:
-    import katsdptelstate
+    import katsdptelstate.endpoint
 except ImportError:
     pass
 
@@ -146,11 +146,15 @@ class ArgumentParser(argparse.ArgumentParser):
         else:
             if config_args.telstate is not None:
                 try:
+                    namespace.telstate_endpoint = \
+                        katsdptelstate.endpoint.endpoint_parser(6379)(config_args.telstate)
                     namespace.telstate = katsdptelstate.TelescopeState(config_args.telstate)
                 except katsdptelstate.ConnectionError as e:
                     self.error(str(e))
                 namespace.name = config_args.name
                 self._load_defaults(namespace.telstate, namespace.name)
+            else:
+                namespace.telstate_endpoint = None
         return super().parse_known_args(other, namespace)
 
     def add_aiomonitor_arguments(self):

--- a/katsdpservices/test/test_argparse.py
+++ b/katsdpservices/test/test_argparse.py
@@ -19,6 +19,8 @@
 import unittest
 from unittest import mock
 
+from katsdptelstate.endpoint import Endpoint
+
 from katsdpservices import ArgumentParser
 
 
@@ -77,6 +79,7 @@ class TestArgumentParser(unittest.TestCase):
             ['hello', '--int-arg=3', '--float-arg=2.5', '--no-default=test', '--bool-arg',
              '--group-int=11', '--mutual-y=z'])
         self.assertIsNone(args.telstate)
+        self.assertIsNone(args.telstate_endpoint)
         self.assertEqual('', args.name)
         self.assertEqual('hello', args.positional)
         self.assertEqual(3, args.int_arg)
@@ -103,6 +106,7 @@ class TestArgumentParser(unittest.TestCase):
         """Passing --telstate but not --name loads from root config"""
         args = self.parser.parse_args(['hello', '--telstate=example.com'])
         self.assertIs(self.TelescopeState.return_value, args.telstate)
+        self.assertEqual(Endpoint('example.com', 6379), args.telstate_endpoint)
         self.assertEqual('', args.name)
         self.assertEqual(10, args.int_arg)
         self.assertEqual(4.5, args.float_arg)
@@ -117,6 +121,7 @@ class TestArgumentParser(unittest.TestCase):
         """Passing a nested name loads from all levels of the hierarchy"""
         args = self.parser.parse_args(['hello', '--telstate=example.com', '--name=level1.level2'])
         self.assertIs(self.TelescopeState.return_value, args.telstate)
+        self.assertEqual(Endpoint('example.com', 6379), args.telstate_endpoint)
         self.assertEqual('level1.level2', args.name)
         self.assertEqual('hello', args.positional)
         self.assertEqual(11, args.int_arg)


### PR DESCRIPTION
While the telstate attribute is useful for talking to telstate
synchronously, if one needs to establish an async connection one needs
the original endpoint.