### PR TITLE
Add --aiomonitor-webui-port command-line option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,17 @@
 -d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
+aiohttp==3.9.3            # via aiomonitor
+aioconsole==0.7.0         # via aiomonitor
 aiomonitor==0.7.0
+backports-strenum==1.3.1  # via aiomonitor
+click==8.1.7              # via aiomonitor
+janus==1.0.0              # via aiomonitor
+jinja2==3.1.3             # via aiomonitor
+markupsafe==2.1.5         # via jinja2
 netifaces
+prompt-toolkit==3.0.43    # via aiomonitor
 pygelf
+trafaret==2.1.1           # via aiomonitor
+wcwidth==0.2.13           # via prompt-toolkit
+
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
--c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+-d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
-aiomonitor
+aiomonitor==0.7.0
 netifaces
 pygelf
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/src/katsdpservices/aiomonitor.py
+++ b/src/katsdpservices/aiomonitor.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2020, National Research Foundation (Square Kilometre Array)
+# Copyright (c) 2017-2020, 2024, National Research Foundation (Square Kilometre Array)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -15,6 +15,8 @@
 ################################################################################
 
 """Utilities to simplify starting aiomonitor"""
+
+import inspect
 
 
 class _DummyContext:
@@ -52,12 +54,17 @@ def start_aiomonitor(loop, args, locals):
     if not args.aiomonitor:
         return _DummyContext()
     else:
+        # Add this only if aiomonitor is new enough to support it
+        kwargs = {}
+        if 'webui_port' in inspect.signature(aiomonitor.start_monitor).parameters:
+            kwargs['webui_port'] = args.aiomonitor_webui_port
         return aiomonitor.start_monitor(
             loop=loop,
             host=args.aiomonitor_host,
             port=args.aiomonitor_port,
             console_port=args.aioconsole_port,
-            locals=locals)
+            locals=locals,
+            **kwargs)
 
 
 def add_aiomonitor_arguments(parser):
@@ -65,12 +72,19 @@ def add_aiomonitor_arguments(parser):
 
     See :func:`.start_aiomonitor` for details.
 
+    The :option:`--aiomonitor-webui-port` option is added unconditionally,
+    but ignored if aiomonitor is older than 0.6.0.
+
     Parameters
     ----------
     parser : :class:`argparse.ArgumentParser`
         Parser to which arguments will be added.
     """
     import aiomonitor
+
+    # Fallback to providing our own copy of the default value if the symbolic
+    # constant doesn't exist.
+    default_webui_port = getattr(aiomonitor, 'MONITOR_WEBUI_PORT', 20102)
     parser.add_argument(
         '--aiomonitor', action='store_true', default=False,
         help='run aiomonitor debugging server')
@@ -79,7 +93,10 @@ def add_aiomonitor_arguments(parser):
         help='bind host for aiomonitor/aioconsole [%(default)s]')
     parser.add_argument(
         '--aiomonitor-port', type=int, default=aiomonitor.MONITOR_PORT,
-        help='port for aiomonitor [%(default)s]')
+        help='port for aiomonitor terminal UI [%(default)s]')
     parser.add_argument(
         '--aioconsole-port', type=int, default=aiomonitor.CONSOLE_PORT,
         help='port for aioconsole [%(default)s]')
+    parser.add_argument(
+        '--aiomonitor-webui-port', type=int, default=default_webui_port,
+        help='port for aiomonitor web UI [%(default)s]')

--- a/test/test_aiomonitor.py
+++ b/test/test_aiomonitor.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017-2020, 2022, National Research Foundation (SARAO)
+# Copyright (c) 2017-2020, 2022, 2024 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -29,7 +29,7 @@ class TestStartAiomonitor(unittest.TestCase):
     def setUp(self):
         self.parser = ArgumentParser()
         add_aiomonitor_arguments(self.parser)
-        patcher = mock.patch('aiomonitor.start_monitor')
+        patcher = mock.patch('aiomonitor.start_monitor', autospec=True)
         self.mock_start = patcher.start()
         self.addCleanup(patcher.stop)
         self.loop = asyncio.new_event_loop()
@@ -49,6 +49,7 @@ class TestStartAiomonitor(unittest.TestCase):
             loop=self.loop, host=aiomonitor.MONITOR_HOST,
             port=aiomonitor.MONITOR_PORT,
             console_port=aiomonitor.CONSOLE_PORT,
+            webui_port=aiomonitor.MONITOR_WEBUI_PORT,
             locals=locals_)
 
     def test_explicit(self):
@@ -56,6 +57,7 @@ class TestStartAiomonitor(unittest.TestCase):
             ['--aiomonitor',
              '--aiomonitor-host', 'example.com',
              '--aiomonitor-port', '1234',
+             '--aiomonitor-webui-port', '4321',
              '--aioconsole-port', '2345'])
         locals_ = {'hello': 'world'}
         with start_aiomonitor(self.loop, args, locals_):
@@ -64,4 +66,5 @@ class TestStartAiomonitor(unittest.TestCase):
             loop=self.loop, host='example.com',
             port=1234,
             console_port=2345,
+            webui_port=4321,
             locals=locals_)


### PR DESCRIPTION
This option controls the port that aiomonitor 0.6.0+ opens for the new web UI. Even if we aren't making use of the web UI, we need control over the port it's using so that we can assign unique ports when multiple processes run on the same machine.