### PR TITLE
Unpin requirements and use katsdpdockerbase versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,7 @@
--d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
-aiohttp==3.9.3            # via aiomonitor
-aioconsole==0.7.0         # via aiomonitor
-aiomonitor==0.7.0
-backports-strenum==1.3.1  # via aiomonitor
-click==8.1.7              # via aiomonitor
-janus==1.0.0              # via aiomonitor
-jinja2==3.1.3             # via aiomonitor
-markupsafe==2.1.5         # via jinja2
+aiomonitor
 netifaces
-prompt-toolkit==3.0.43    # via aiomonitor
 pygelf
-trafaret==2.1.1           # via aiomonitor
-wcwidth==0.2.13           # via prompt-toolkit
 
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate


### PR DESCRIPTION
Newer versions had been pinned because katsdpdockerbase was far behind prior to ska-sa/katsdpdockerbase#112. Unpin them and use the katsdpdockerbase versions.

This does cause prompt-toolkit and click to regress to older versions.