### PR TITLE
Updates to support Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 7.1.0
   hooks:
     - id: flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 install_requires =
     netifaces
     pygelf >= 0.3.6
-python_requires = >=3.5
+python_requires = >=3.8
 
 [options.packages.find]
 where = src

--- a/src/katsdpservices/logging.py
+++ b/src/katsdpservices/logging.py
@@ -122,16 +122,16 @@ class _TimestampFilter(logging.Filter):
 
     The timestamp is formatted according to ISO8601 with microsecond
     precision. This is to work around the lack of native sub-ms
-    timestamp support in logstash
+    timestamp support in logstash 7.x
     (https://github.com/elastic/logstash/issues/10822).
 
-    While Elasticsearch supports nanosecond timestamps, Python versions
-    before 3.7 can't do better than about 200ns precision because they
-    represent time as 64-bit float seconds since the UNIX epoch, and
-    it doesn't seem worth the effort to go finer than microseconds.
+    While Elasticsearch supports nanosecond timestamps, LogRecord
+    stores the creation time as a 64-bit float so is limited to about 200ns
+    precision, and it doesn't seem worth the effort to go finer than
+    microseconds.
     """
     def filter(self, record):
-        dt = datetime.datetime.utcfromtimestamp(record.created)
+        dt = datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
         record.timestamp_precise = dt.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         return True
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -16,17 +16,18 @@
 
 """Tests for :mod:`katsdpservices.logging`"""
 
-import time
+import io
+import json
 import logging
-import socket
 import os
 import re
-import io
 import signal
-import json
+import socket
+import sys
+import time
+import unittest
 import zlib
 from contextlib import closing
-import unittest
 from unittest import mock
 
 import katsdpservices
@@ -152,6 +153,8 @@ class TestLogging(unittest.TestCase):
             expected["_hello"] = "world"
             expected["_number"] = 3
         expected["_stack_info"] = None
+        if sys.version_info >= (3, 12, 0):
+            expected["_taskName"] = None
         self.assertEqual(data, expected)
 
     def test_gelf_basic(self):


### PR DESCRIPTION
- Remove use of deprecated datetime.utcfromtimestamp.
- Fix unit tests to cope with LogRecord.taskName property (added in Python 3.12).
- Update flake8 to latest version (old version does not work with Python 3.12).